### PR TITLE
Release 2.6.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 
 #### 2.x Releases
 
+## [2.6.0](https://github.com/checkout/checkout-ios-components/releases/tag/2.6.0)
+
+Released on 27.08.2026
+
+Updates:
+
+- **What's new**
+   - [ADDED] Merchant Saved Card component
+   - [ADDED] CVV component
+   - [ADDED] Support for Remember Me countries: Jordan, Kuwait, Morocco, Palestine, and Tunisia
+   - [UPDATED] OnTokenised callback now includes consent checkbox value
+   - [UPDATED] Remember Me wallet now displays a Pay button for each row
+
+##
+
 ## [2.5.0](https://github.com/checkout/checkout-ios-components/releases/tag/2.5.0)
 
 Released on 03.08.2026
@@ -89,6 +104,21 @@ Updates:
 ##
 
 #### 1.x Releases
+
+## [2.6.0](https://github.com/checkout/checkout-ios-components/releases/tag/2.6.0)
+
+Released on 27.08.2026
+
+Updates:
+
+- **What's new**
+   - [ADDED] Merchant Saved Card component
+   - [ADDED] CVV component
+   - [ADDED] Support for Remember Me countries: Jordan, Kuwait, Morocco, Palestine, and Tunisia
+   - [UPDATED] OnTokenised callback now includes consent checkbox value
+   - [UPDATED] Remember Me wallet now displays a Pay button for each row
+
+##
 
 ## [2.5.0](https://github.com/checkout/checkout-ios-components/releases/tag/2.5.0)
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,12 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let releaseVersion = "2.6.0"
+let releaseVersion = "2.6.0-rc"
 let githubRepo = "checkout/checkout-ios-components"
 
-let sdkChecksum = "c8f6249c2d4829e022fee445a66a337be28e04a6aa2dce4d5b93242b66e725bf"
-let paymentMethodsChecksum = "f4ce48bbbed50c3c6f765d06f105471a4ee9cd325697e494d973fce0137de59a"
-let klarnaChecksum = "494238d5d034b4ed04cea42439c5d83d185eb956968ae96e6128e7f1e3be0767"
+let sdkChecksum = "1ebbbd4fd39a4223cbddafecee9bc7377c1a3071333b77637c50039d6f890071"
+let paymentMethodsChecksum = "481fb9062e1de0f58d513cebf1e392c4b342d4b269b6a7e73fc11867fb3398a8"
+let klarnaChecksum = "6ae7355a826489807aba82ea168f3e8446330f259c8b163f9094ea8a1cf1182a"
 
 let sdkURL = "https://github.com/\(githubRepo)/releases/download/\(releaseVersion)/CheckoutComponentsSDK.xcframework.zip"
 let paymentMethodsURL = "https://github.com/\(githubRepo)/releases/download/\(releaseVersion)/CheckoutPaymentMethods.xcframework.zip"

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let releaseVersion = "2.6.0-rc"
+let releaseVersion = "2.6.0"
 let githubRepo = "checkout/checkout-ios-components"
 
 let sdkChecksum = "1ebbbd4fd39a4223cbddafecee9bc7377c1a3071333b77637c50039d6f890071"

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,12 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let releaseVersion = "2.5.0"
+let releaseVersion = "2.6.0"
 let githubRepo = "checkout/checkout-ios-components"
 
-let sdkChecksum = "64610582864b26695f24b052313a71299a20e73fe3af8f4ea17500c5e6cb2c97"
-let paymentMethodsChecksum = "63ab92eb67b6f5e8f58be4d2f632ccc794b399908765655e0cce50071e2db38c"
-let klarnaChecksum = "4f4f517e22d399faad8fd89bc3add9579f4418ecdfdd9fb12f3ab065b7dc241d"
+let sdkChecksum = "c8f6249c2d4829e022fee445a66a337be28e04a6aa2dce4d5b93242b66e725bf"
+let paymentMethodsChecksum = "f4ce48bbbed50c3c6f765d06f105471a4ee9cd325697e494d973fce0137de59a"
+let klarnaChecksum = "494238d5d034b4ed04cea42439c5d83d185eb956968ae96e6128e7f1e3be0767"
 
 let sdkURL = "https://github.com/\(githubRepo)/releases/download/\(releaseVersion)/CheckoutComponentsSDK.xcframework.zip"
 let paymentMethodsURL = "https://github.com/\(githubRepo)/releases/download/\(releaseVersion)/CheckoutPaymentMethods.xcframework.zip"

--- a/SampleApplication/Release-SPM-File/CheckoutComponentsPackage/dummy.swift
+++ b/SampleApplication/Release-SPM-File/CheckoutComponentsPackage/dummy.swift
@@ -1,0 +1,5 @@
+// SPM requires every regular target to contain at least one source file.
+// `CheckoutComponentsPackage` is a thin wrapper target that exposes the
+// `CheckoutComponentsSDK` binary target through SPM's product graph; it has
+// no real implementation of its own. This empty file satisfies that
+// requirement without affecting the published binary.

--- a/SampleApplication/Release-SPM-File/Package.swift
+++ b/SampleApplication/Release-SPM-File/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let releaseVersion = "2.6.0"
+let githubRepo = "cko-mobile/checkout-ios-components"
+
+let sdkChecksum = "c8f6249c2d4829e022fee445a66a337be28e04a6aa2dce4d5b93242b66e725bf"
+
+let sdkURL = "https://github.com/\(githubRepo)/releases/download/\(releaseVersion)/CheckoutComponentsSDK.xcframework.zip"
+
+let package = Package(
+  name: "CheckoutComponents",
+  defaultLocalization: "en-GB",
+  platforms: [
+    .iOS(.v15)
+  ],
+  products: [
+    .library(
+      name: "CheckoutComponents",
+      targets: [
+        "CheckoutComponentsPackage"
+      ]
+    ),
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/checkout/checkout-risk-sdk-ios",
+      from: "4.0.1"
+    )
+  ],
+  targets: [
+    .target(
+      name: "CheckoutComponentsPackage",
+      dependencies: [
+        .product(name: "Risk", package: "checkout-risk-sdk-ios"),
+        .target(name: "CheckoutComponentsSDK"),
+      ],
+      path: "CheckoutComponentsPackage"
+    ),
+    .binaryTarget(
+      name: "CheckoutComponentsSDK",
+      url: sdkURL,
+      checksum: sdkChecksum
+    )
+  ]
+)

--- a/SampleApplication/SampleApplication.xcodeproj/project.pbxproj
+++ b/SampleApplication/SampleApplication.xcodeproj/project.pbxproj
@@ -26,7 +26,10 @@
 		A21EBD622DF8007900F9BC14 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21EBD612DF8007900F9BC14 /* AccessibilityIdentifiers.swift */; };
 		A21EBD682DFAD9ED00F9BC14 /* MainView+SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21EBD672DFAD9ED00F9BC14 /* MainView+SettingsView.swift */; };
 		A21EBD6A2E005C2D00F9BC14 /* AddressComponentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21EBD692E005C2D00F9BC14 /* AddressComponentConfiguration.swift */; };
+		A21EBD6C2E005C2E00F9BC14 /* MainView+SettingsView+AcceptedCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21EBD6B2E005C2E00F9BC14 /* MainView+SettingsView+AcceptedCards.swift */; };
 		A26B7BEB2E27CD1200B1E840 /* SubmitPaymentSessionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26B7BEA2E27CD1200B1E840 /* SubmitPaymentSessionRequest.swift */; };
+		A2CB10022F9E00020085BAA1 /* CallbackLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CB10012F9E00010085BAA1 /* CallbackLogView.swift */; };
+		A2CB10062F9E00060085BAA1 /* CallbackInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CB10052F9E00050085BAA1 /* CallbackInfoStore.swift */; };
 		A2D1C7832FBCD82C0085BAA0 /* MainViewModel+CountryCurrencyOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2D1C7822FBCD82C0085BAA0 /* MainViewModel+CountryCurrencyOption.swift */; };
 		A2EF10AD2F22771700CDC478 /* MainViewModel+LocaleOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2EF10AC2F22771700CDC478 /* MainViewModel+LocaleOption.swift */; };
 		CC10C0F100000000000000A2 /* LaunchConfigHydrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC10C0F100000000000000A1 /* LaunchConfigHydrator.swift */; };
@@ -68,7 +71,10 @@
 		A21EBD612DF8007900F9BC14 /* AccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifiers.swift; sourceTree = "<group>"; };
 		A21EBD672DFAD9ED00F9BC14 /* MainView+SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainView+SettingsView.swift"; sourceTree = "<group>"; };
 		A21EBD692E005C2D00F9BC14 /* AddressComponentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressComponentConfiguration.swift; sourceTree = "<group>"; };
+		A21EBD6B2E005C2E00F9BC14 /* MainView+SettingsView+AcceptedCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainView+SettingsView+AcceptedCards.swift"; sourceTree = "<group>"; };
 		A26B7BEA2E27CD1200B1E840 /* SubmitPaymentSessionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitPaymentSessionRequest.swift; sourceTree = "<group>"; };
+		A2CB10012F9E00010085BAA1 /* CallbackLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallbackLogView.swift; sourceTree = "<group>"; };
+		A2CB10052F9E00050085BAA1 /* CallbackInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallbackInfoStore.swift; sourceTree = "<group>"; };
 		A2D1C7822FBCD82C0085BAA0 /* MainViewModel+CountryCurrencyOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewModel+CountryCurrencyOption.swift"; sourceTree = "<group>"; };
 		A2EF10AC2F22771700CDC478 /* MainViewModel+LocaleOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewModel+LocaleOption.swift"; sourceTree = "<group>"; };
 		CC10C0F100000000000000A1 /* LaunchConfigHydrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchConfigHydrator.swift; sourceTree = "<group>"; };
@@ -175,6 +181,8 @@
 			children = (
 				9513C3232C47FC0C0018BB7E /* MainView.swift */,
 				A21EBD672DFAD9ED00F9BC14 /* MainView+SettingsView.swift */,
+				A21EBD6B2E005C2E00F9BC14 /* MainView+SettingsView+AcceptedCards.swift */,
+				A2CB10012F9E00010085BAA1 /* CallbackLogView.swift */,
 				951299012CBD788F00DC1715 /* PaymentResultView.swift */,
 				953809272D92D09E003B5C21 /* NavigationHelper.swift */,
 			);
@@ -215,6 +223,7 @@
 			isa = PBXGroup;
 			children = (
 				A21EBD612DF8007900F9BC14 /* AccessibilityIdentifiers.swift */,
+				A2CB10052F9E00050085BAA1 /* CallbackInfoStore.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -358,6 +367,9 @@
 				CC10C0F100000000000000A2 /* LaunchConfigHydrator.swift in Sources */,
 				A2EF10AD2F22771700CDC478 /* MainViewModel+LocaleOption.swift in Sources */,
 				A21EBD682DFAD9ED00F9BC14 /* MainView+SettingsView.swift in Sources */,
+				A21EBD6C2E005C2E00F9BC14 /* MainView+SettingsView+AcceptedCards.swift in Sources */,
+				A2CB10022F9E00020085BAA1 /* CallbackLogView.swift in Sources */,
+				A2CB10062F9E00060085BAA1 /* CallbackInfoStore.swift in Sources */,
 				95EC13982CB446A200812B24 /* MainViewModel+CallbacksProvider.swift in Sources */,
 				1699DC712C74F5500069008D /* SampleApplication.swift in Sources */,
 				A2D1C7832FBCD82C0085BAA0 /* MainViewModel+CountryCurrencyOption.swift in Sources */,

--- a/SampleApplication/SampleApplication/Helpers/AccessibilityIdentifiers.swift
+++ b/SampleApplication/SampleApplication/Helpers/AccessibilityIdentifiers.swift
@@ -6,6 +6,20 @@ enum AccessibilityIdentifier {
   enum MainView: String {
     case renderFlowComponent = "render_flow_component_button"
     case settingsButton = "settings_button"
+    case cvvTokenLabel = "cvv_token_label"
+    case cvvTokenizationErrorLabel = "cvv_tokenization_error_label"
+    case merchantSubmitButton = "merchant_submit_button"
+    case callbackLogButton = "callback_log_button"
+  }
+
+  enum CallbackLogView: String {
+    case screen = "callback_log_screen"
+    case closeButton = "callback_log_close_button"
+    case clearButton = "callback_log_clear_button"
+
+    static func entry(index: Int) -> String {
+      "callback_log_entry_\(index)"
+    }
   }
   
   enum SettingsView: String {
@@ -38,6 +52,7 @@ enum AccessibilityIdentifier {
     case payment = "payment"
     case tokenize = "tokenize"
     case showPayButtonPicker = "show_pay_button_picker"
+    case submitPaymentPicker = "submit_payment_picker"
     case submitPaymentMethodView = "submit_payment_method_view"
     case hideSecurityCodeToggle = "hide_security_code_toggle"
     case acceptedCardSchemesPicker = "accepted_card_schemes_picker"
@@ -60,6 +75,24 @@ enum AccessibilityIdentifier {
     case captureCvvFeatureFlagToggle = "capture_cvv_feature_flag_toggle"
     case hidePrefilledDataFeatureFlagToggle = "hide_prefilled_data_feature_flag_toggle"
     case rememberMeDiscreetUIFeatureFlagToggle = "remember_me_discreet_ui_feature_flag_toggle"
+
+    // Stored Card
+    case storedCardConfigurationsExpandable = "stored_card_configurations"
+    case storedCardSourcePicker = "stored_card_source_picker"
+    case customerIdTextField = "customer_id_textfield"
+    case instrumentIdsTextField = "instrument_ids_textfield"
+    case defaultInstrumentIdTextField = "default_instrument_id_textfield"
+    case storedCardDisplayModePicker = "stored_card_display_mode_picker"
+    case showStoredCardPayButtonToggle = "show_stored_card_pay_button_toggle"
+    case storedCardCaptureCVVToggle = "stored_card_capture_cvv_toggle"
+    case storedCardPaymentButtonActionPicker = "stored_card_payment_button_action_picker"
+    case storedCardPaymentAction = "stored_card_payment_action"
+    case storedCardTokenizeAction = "stored_card_tokenize_action"
+    case storePaymentDetailsPicker = "store_payment_details_picker"
+
+    // CVV
+    case cvvConfigurationsExpandable = "cvv_configurations"
+    case cvvLengthPicker = "cvv_length_picker"
 
     // SDK RememberMe config
     case rememberMeSDKSetupExpandable = "remember_me_sdk_setup"

--- a/SampleApplication/SampleApplication/Helpers/CallbackInfoStore.swift
+++ b/SampleApplication/SampleApplication/Helpers/CallbackInfoStore.swift
@@ -1,0 +1,34 @@
+//  Copyright © 2026 Checkout.com. All rights reserved.
+
+import Foundation
+
+/// Records every SDK callback fired, oldest first.
+@MainActor
+final class CallbackInfoStore: ObservableObject {
+  @Published private(set) var entries: [String]
+
+  private let defaults: UserDefaults
+  private static let storageKey = "callback_info"
+
+  private static let timestampFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    return formatter
+  }()
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    self.entries = defaults.stringArray(forKey: Self.storageKey) ?? []
+  }
+
+  func add(_ info: String) {
+    entries.append("\(Self.timestampFormatter.string(from: Date())) - \(info)")
+    defaults.set(entries, forKey: Self.storageKey)
+  }
+
+  func clear() {
+    entries = []
+    defaults.removeObject(forKey: Self.storageKey)
+  }
+}

--- a/SampleApplication/SampleApplication/Main/View/CallbackLogView.swift
+++ b/SampleApplication/SampleApplication/Main/View/CallbackLogView.swift
@@ -1,0 +1,38 @@
+//  Copyright © 2026 Checkout.com. All rights reserved.
+
+import SwiftUI
+
+/// Lists every SDK callback fired, oldest first.
+struct CallbackLogView: View {
+  @ObservedObject var store: CallbackInfoStore
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationView {
+      List {
+        ForEach(Array(store.entries.enumerated()), id: \.offset) { index, entry in
+          Text(entry)
+            .font(.caption)
+            .accessibilityIdentifier(AccessibilityIdentifier.CallbackLogView.entry(index: index + 1))
+        }
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.CallbackLogView.screen.rawValue)
+      .navigationTitle("Callback Info")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Delete") { store.clear() }
+            .accessibilityIdentifier(AccessibilityIdentifier.CallbackLogView.clearButton.rawValue)
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button("OK") { dismiss() }
+            .accessibilityIdentifier(AccessibilityIdentifier.CallbackLogView.closeButton.rawValue)
+        }
+      }
+    }
+  }
+}
+
+#Preview {
+  CallbackLogView(store: CallbackInfoStore())
+}

--- a/SampleApplication/SampleApplication/Main/View/MainView+SettingsView+AcceptedCards.swift
+++ b/SampleApplication/SampleApplication/Main/View/MainView+SettingsView+AcceptedCards.swift
@@ -1,0 +1,154 @@
+//  Copyright © 2024 Checkout.com. All rights reserved.
+
+#if canImport(CheckoutComponents)
+import CheckoutComponents
+#elseif canImport(CheckoutComponentsSDK)
+import CheckoutComponentsSDK
+#endif
+
+import SwiftUI
+
+// MARK: - Accepted card schemes
+
+extension MainView {
+  private var allCardSchemes: [CardScheme] {
+    [
+      .americanExpress, .cartesBancaires,
+      .chinaUnionPay, .dinersClub,
+      .discover, .jcb,
+      .mada, .jaywan, .mastercard,
+      .visa, .maestro
+    ]
+  }
+
+  func acceptedCardSchemesPicker(title: String,
+                                 selectedSchemes: Binding<Set<CardScheme>>,
+                                 accessibilityIdentifierSuffix: String) -> some View {
+    DisclosureGroup {
+      ForEach(allCardSchemes, id: \.self) { scheme in
+        Button(action: {
+          if selectedSchemes.wrappedValue.contains(scheme) {
+            selectedSchemes.wrappedValue.remove(scheme)
+          } else {
+            selectedSchemes.wrappedValue.insert(scheme)
+          }
+        }) {
+          HStack {
+            Text(scheme.rawValue.capitalized)
+            Spacer()
+            if selectedSchemes.wrappedValue.contains(scheme) {
+              Image(systemName: "checkmark")
+                .foregroundColor(.accentColor)
+            }
+          }
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+      }
+    } label: {
+      Text(title)
+        .foregroundColor(.primary)
+        .multilineTextAlignment(.leading)
+    }
+    .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.acceptedCardSchemesPicker.rawValue + accessibilityIdentifierSuffix)
+  }
+
+  var cardAcceptedCardSchemesView: some View {
+    acceptedCardSchemesPicker(title: "Card accepted card schemes:",
+                              selectedSchemes: $viewModel.cardAcceptedCardSchemes,
+                              accessibilityIdentifierSuffix: "_card")
+  }
+
+  var applePayAcceptedCardSchemesView: some View {
+    acceptedCardSchemesPicker(title: "Apple Pay accepted card schemes:",
+                              selectedSchemes: $viewModel.applePayAcceptedCardSchemes,
+                              accessibilityIdentifierSuffix: "_apple_pay")
+  }
+
+  var rememberMeAcceptedCardSchemesView: some View {
+    acceptedCardSchemesPicker(title: "Remember Me accepted card schemes:",
+                              selectedSchemes: $viewModel.rememberMeAcceptedCardSchemes,
+                              accessibilityIdentifierSuffix: "_remember_me")
+  }
+
+  var storedCardAcceptedCardSchemesView: some View {
+    acceptedCardSchemesPicker(title: "Stored Card accepted card schemes:",
+                              selectedSchemes: $viewModel.storedCardAcceptedCardSchemes,
+                              accessibilityIdentifierSuffix: "_stored_card")
+  }
+}
+
+// MARK: - Accepted card types
+
+extension MainView {
+  private var allCardTypes: [CheckoutComponents.CardType] {
+    [
+      .credit, .debit,
+      .prepaid, .charge,
+      .deferredDebit
+    ]
+  }
+
+  func acceptedCardTypesPicker(title: String,
+                               selectedTypes: Binding<Set<CheckoutComponents.CardType>>,
+                               cardTypes: [CheckoutComponents.CardType],
+                               accessibilityIdentifierSuffix: String) -> some View {
+    DisclosureGroup {
+      ForEach(cardTypes, id: \.self) { type in
+        Button(action: {
+          if selectedTypes.wrappedValue.contains(type) {
+            selectedTypes.wrappedValue.remove(type)
+          } else {
+            selectedTypes.wrappedValue.insert(type)
+          }
+        }) {
+          HStack {
+            Text(type.rawValue.capitalized)
+            Spacer()
+            if selectedTypes.wrappedValue.contains(type) {
+              Image(systemName: "checkmark")
+                .foregroundColor(.accentColor)
+            }
+          }
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+      }
+    } label: {
+      Text(title)
+        .accessibilityIdentifier(title)
+        .foregroundColor(.primary)
+        .multilineTextAlignment(.leading)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.acceptedCardTypesPicker.rawValue + accessibilityIdentifierSuffix)
+  }
+
+  var cardAcceptedCardTypesView: some View {
+    acceptedCardTypesPicker(title: "Card accepted card types:",
+                            selectedTypes: $viewModel.cardAcceptedCardTypes,
+                            cardTypes: allCardTypes,
+                            accessibilityIdentifierSuffix: "_card")
+  }
+
+  var applePayAcceptedCardTypesView: some View {
+    acceptedCardTypesPicker(title: "Apple Pay accepted card types:",
+                            selectedTypes: $viewModel.applePayAcceptedCardTypes,
+                            cardTypes: [.credit, .debit],
+                            accessibilityIdentifierSuffix: "_apple_pay")
+  }
+
+  var rememberMeAcceptedCardTypesView: some View {
+    acceptedCardTypesPicker(title: "RememberMe accepted card types:",
+                            selectedTypes: $viewModel.rememberMeAcceptedCardTypes,
+                            cardTypes: allCardTypes,
+                            accessibilityIdentifierSuffix: "_remember_me")
+  }
+
+  var storedCardAcceptedCardTypesView: some View {
+    acceptedCardTypesPicker(title: "Stored Card accepted card types:",
+                            selectedTypes: $viewModel.storedCardAcceptedCardTypes,
+                            cardTypes: allCardTypes,
+                            accessibilityIdentifierSuffix: "_stored_card")
+  }
+}

--- a/SampleApplication/SampleApplication/Main/View/MainView+SettingsView.swift
+++ b/SampleApplication/SampleApplication/Main/View/MainView+SettingsView.swift
@@ -14,7 +14,10 @@ import SwiftUI
 
 enum CheckoutComponent: String, CaseIterable {
   case flow = "Flow"
+  case address = "Address"
+  case cvv = "CVV"
   case card = "Card"
+  case storedCard = "Stored Card"
   case applePay = "Apple Pay"
   case tabby = "Tabby"
   case tamara = "Tamara"
@@ -23,12 +26,24 @@ enum CheckoutComponent: String, CaseIterable {
   case klarna = "Klarna"
 #endif
 
+  /// Address and CVV are `SessionlessComponent` cases, so the SDK renders them with just the
+  /// public key and the sample app skips the payment session call for them.
+  var isSessionless: Bool {
+    self == .address || self == .cvv
+  }
+
   var accessibilityIdentifier: String {
     switch self {
     case .flow:
       return "flow"
+    case .address:
+      return "address"
+    case .cvv:
+      return "cvv"
     case .card:
       return "card"
+    case .storedCard:
+      return "stored_card"
     case .applePay:
       return "google_apple_pay"
     case .tabby:
@@ -50,6 +65,58 @@ enum ApplePayType: String, CaseIterable {
   case pending
 }
 
+
+/// The security code lengths `CardCVVConfiguration` accepts.
+enum CVVLength: UInt, CaseIterable {
+  case three = 3
+  case four = 4
+
+  var accessibilityIdentifier: String {
+    "cvv_length_\(rawValue)"
+  }
+}
+
+enum StorePaymentDetailsOption: String, CaseIterable {
+  case enabled
+  case disabled
+  case undefined
+  case collectConsent = "collect_consent"
+
+  var displayName: String {
+    switch self {
+    case .enabled: return "Enabled"
+    case .disabled: return "Disabled"
+    case .undefined: return "Undefined"
+    case .collectConsent: return "Collect consent"
+    }
+  }
+
+  /// `undefined` omits `store_payment_details` from the payment session request.
+  var requestValue: String? {
+    self == .undefined ? nil : rawValue
+  }
+}
+
+enum StoredCardSource: String, CaseIterable {
+  /// Omits `stored_card` from the request.
+  case none
+
+  /// Sends `instrument_ids` with the exact instruments to expose, optionally with
+  /// `default_instrument_id` to pick which of them is pre-selected.
+  case instrumentIds = "instrument_ids"
+
+  /// Sends `customer_id` and lets the backend resolve that customer's instruments.
+  case customerId = "customer_id"
+
+  var displayName: String {
+    switch self {
+    case .none: return "None"
+    case .instrumentIds: return "Instrument ids"
+    case .customerId: return "Customer id"
+    }
+  }
+}
+
 extension MainView {
   var settingView: some View {
     ScrollView {
@@ -68,6 +135,8 @@ extension MainView {
         advancedFeaturesView
         paymentSessionConfigurationView
         rememberMeConfigurationsView
+        storedCardConfigurationsView
+        cvvConfigurationsView
         #if canImport(CheckoutKlarnaSDK)
         klarnaConfigurationsView
         #endif
@@ -146,7 +215,8 @@ extension MainView {
 
         Text("handleSubmit callback")
           .tag(true)
-      }.accessibilityIdentifier(AccessibilityIdentifier.SettingsView.showPayButtonPicker.rawValue)
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.submitPaymentPicker.rawValue)
     }
   }
 
@@ -390,6 +460,183 @@ extension MainView {
       .transition(.opacity.combined(with: .slide))
     }
   }
+  
+  var storedCardConfigurationsView: some View {
+    expandableSection(title: "Stored Card Configurations",
+                      isExpanded: $viewModel.isStoredCardExpanded,
+                      accessibilityIdentifier: AccessibilityIdentifier.SettingsView.storedCardConfigurationsExpandable.rawValue) {
+      VStack(alignment: .leading, spacing: 12) {
+        storedCardSourceView
+
+        switch viewModel.storedCardSource {
+        case .none:
+          EmptyView()
+
+        case .instrumentIds:
+          instrumentIds
+          defaultInstrumentId
+
+        case .customerId:
+          customerId
+        }
+
+        storedCardDisplayModeView
+        storePaymentDetailsView
+        showStoredCardPayButtonView
+        if viewModel.showStoredCardPayButton {
+          storedCardPaymentButtonActionView
+        }
+        storedCardCaptureCVVView
+        storedCardAcceptedCardSchemesView
+        storedCardAcceptedCardTypesView
+      }
+    }
+    .transition(.opacity.combined(with: .slide))
+  }
+
+  var showStoredCardPayButtonView: some View {
+    Toggle("Show Stored Card pay button", isOn: $viewModel.showStoredCardPayButton)
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.showStoredCardPayButtonToggle.rawValue)
+  }
+
+  /// Only affects the Card component embedded in the "Use a new card" row.
+  var storedCardPaymentButtonActionView: some View {
+    HStack {
+      Text("Payment button action:")
+
+      Picker("Payment button action",
+             selection: $viewModel.storedCardPaymentButtonAction) {
+        Text("Payment")
+          .tag(CheckoutComponents.PaymentButtonAction.payment)
+          .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storedCardPaymentAction.rawValue)
+
+        Text("Tokenize")
+          .tag(CheckoutComponents.PaymentButtonAction.tokenization)
+          .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storedCardTokenizeAction.rawValue)
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storedCardPaymentButtonActionPicker.rawValue)
+    }
+  }
+
+  var storedCardCaptureCVVView: some View {
+    Toggle("Capture CVV", isOn: $viewModel.storedCardCaptureCVV)
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storedCardCaptureCVVToggle.rawValue)
+  }
+
+  var storedCardDisplayModeView: some View {
+    HStack {
+      Text("Display mode:")
+
+      Picker("Display mode", selection: $viewModel.storedCardDisplayMode) {
+        ForEach(CheckoutComponents.StoredCardDisplayMode.allCases, id: \.self) {
+          Text($0.displayName)
+            .tag($0)
+            .accessibilityIdentifier($0.rawValue)
+        }
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storedCardDisplayModePicker.rawValue)
+    }
+  }
+
+  var storePaymentDetailsView: some View {
+    HStack {
+      Text("Store payment details:")
+
+      Picker("Store payment details", selection: $viewModel.storePaymentDetails) {
+        ForEach(StorePaymentDetailsOption.allCases, id: \.self) {
+          Text($0.displayName)
+            .tag($0)
+            .accessibilityIdentifier($0.rawValue)
+        }
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storePaymentDetailsPicker.rawValue)
+    }
+  }
+
+  var storedCardSourceView: some View {
+    HStack {
+      Text("Source:")
+
+      Picker("Source", selection: $viewModel.storedCardSource) {
+        ForEach(StoredCardSource.allCases, id: \.self) {
+          Text($0.displayName)
+            .tag($0)
+            .accessibilityIdentifier($0.rawValue)
+        }
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.storedCardSourcePicker.rawValue)
+    }
+  }
+
+  var customerId: some View {
+    HStack {
+      Text("Customer id: ")
+      TextField("Customer id", text: $viewModel.customerId)
+        .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.customerIdTextField.rawValue)
+    }
+  }
+
+  var instrumentIds: some View {
+    HStack {
+      Text("Instrument ids: ")
+      TextField("Comma-separated", text: $viewModel.instrumentIds)
+        .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.instrumentIdsTextField.rawValue)
+    }
+  }
+
+  /// Names one of the listed instruments, so it is meaningless without the list above.
+  var defaultInstrumentId: some View {
+    HStack {
+      Text("Default instrument id: ")
+      TextField("Optional", text: $viewModel.defaultInstrumentId)
+        .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.defaultInstrumentIdTextField.rawValue)
+    }
+  }
+
+  var cvvConfigurationsView: some View {
+    expandableSection(title: "CVV Configurations",
+                      isExpanded: $viewModel.isCVVExpanded,
+                      accessibilityIdentifier: AccessibilityIdentifier.SettingsView.cvvConfigurationsExpandable.rawValue) {
+      VStack(alignment: .leading, spacing: 12) {
+        cvvLengthView
+      }
+      .padding(.leading, 16)
+      .transition(.opacity.combined(with: .slide))
+    }
+  }
+
+  /// Multi-select so both lengths can be sent together, which is what `[3, 4]` means to the
+  /// component: accept a code of either length.
+  var cvvLengthView: some View {
+    DisclosureGroup {
+      ForEach(CVVLength.allCases, id: \.self) { length in
+        Button(action: {
+          if viewModel.selectedCVVLengths.contains(length) {
+            viewModel.selectedCVVLengths.remove(length)
+          } else {
+            viewModel.selectedCVVLengths.insert(length)
+          }
+        }) {
+          HStack {
+            Text(String(length.rawValue))
+            Spacer()
+            if viewModel.selectedCVVLengths.contains(length) {
+              Image(systemName: "checkmark")
+                .foregroundColor(.accentColor)
+            }
+          }
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(length.accessibilityIdentifier)
+      }
+    } label: {
+      Text("CVV length:")
+        .foregroundColor(.primary)
+        .multilineTextAlignment(.leading)
+    }
+    .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.cvvLengthPicker.rawValue)
+  }
 
   var paymentSessionUsername: some View {
     HStack {
@@ -504,130 +751,6 @@ extension MainView {
     }
   }
   
-  private var allCardSchemes: [CardScheme] {
-    [
-      .americanExpress, .cartesBancaires,
-      .chinaUnionPay, .dinersClub,
-      .discover, .jcb,
-      .mada, .jaywan, .mastercard,
-      .visa, .maestro
-    ]
-  }
-
-  func acceptedCardSchemesPicker(title: String,
-                                 selectedSchemes: Binding<Set<CardScheme>>,
-                                 accessibilityIdentifierSuffix: String) -> some View {
-    DisclosureGroup {
-      ForEach(allCardSchemes, id: \.self) { scheme in
-        Button(action: {
-          if selectedSchemes.wrappedValue.contains(scheme) {
-            selectedSchemes.wrappedValue.remove(scheme)
-          } else {
-            selectedSchemes.wrappedValue.insert(scheme)
-          }
-        }) {
-          HStack {
-            Text(scheme.rawValue.capitalized)
-            Spacer()
-            if selectedSchemes.wrappedValue.contains(scheme) {
-              Image(systemName: "checkmark")
-                .foregroundColor(.accentColor)
-            }
-          }
-          .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-      }
-    } label: {
-      Text(title)
-        .foregroundColor(.primary)
-        .multilineTextAlignment(.leading)
-    }
-    .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.acceptedCardSchemesPicker.rawValue + accessibilityIdentifierSuffix)
-  }
-
-  var cardAcceptedCardSchemesView: some View {
-    acceptedCardSchemesPicker(title: "Card accepted card schemes:",
-                              selectedSchemes: $viewModel.cardAcceptedCardSchemes,
-                              accessibilityIdentifierSuffix: "_card")
-  }
-
-  var applePayAcceptedCardSchemesView: some View {
-    acceptedCardSchemesPicker(title: "Apple Pay accepted card schemes:",
-                              selectedSchemes: $viewModel.applePayAcceptedCardSchemes,
-                              accessibilityIdentifierSuffix: "_apple_pay")
-  }
-  
-  var rememberMeAcceptedCardSchemesView: some View {
-    acceptedCardSchemesPicker(title: "Remember Me accepted card schemes:",
-                              selectedSchemes: $viewModel.rememberMeAcceptedCardSchemes,
-                              accessibilityIdentifierSuffix: "_remember_me")
-  }
-  
-  private var allCardTypes: [CheckoutComponents.CardType] {
-    [
-      .credit, .debit,
-      .prepaid, .charge,
-      .deferredDebit
-    ]
-  }
-  
-  func acceptedCardTypesPicker(title: String,
-                               selectedTypes: Binding<Set<CheckoutComponents.CardType>>,
-                               cardTypes: [CheckoutComponents.CardType],
-                               accessibilityIdentifierSuffix: String) -> some View {
-    DisclosureGroup {
-      ForEach(cardTypes, id: \.self) { type in
-        Button(action: {
-          if selectedTypes.wrappedValue.contains(type) {
-            selectedTypes.wrappedValue.remove(type)
-          } else {
-            selectedTypes.wrappedValue.insert(type)
-          }
-        }) {
-          HStack {
-            Text(type.rawValue.capitalized)
-            Spacer()
-            if selectedTypes.wrappedValue.contains(type) {
-              Image(systemName: "checkmark")
-                .foregroundColor(.accentColor)
-            }
-          }
-          .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-      }
-    } label: {
-      Text(title)
-        .accessibilityIdentifier(title)
-        .foregroundColor(.primary)
-        .multilineTextAlignment(.leading)
-    }
-    .accessibilityElement(children: .combine)
-    .accessibilityIdentifier(AccessibilityIdentifier.SettingsView.acceptedCardTypesPicker.rawValue + accessibilityIdentifierSuffix)
-  }
-  
-  var cardAcceptedCardTypesView: some View {
-    acceptedCardTypesPicker(title: "Card accepted card types:",
-                            selectedTypes: $viewModel.cardAcceptedCardTypes,
-                            cardTypes: allCardTypes,
-                            accessibilityIdentifierSuffix: "_card")
-  }
-  
-  var applePayAcceptedCardTypesView: some View {
-    acceptedCardTypesPicker(title: "Apple Pay accepted card types:",
-                            selectedTypes: $viewModel.applePayAcceptedCardTypes,
-                            cardTypes: [.credit, .debit],
-                            accessibilityIdentifierSuffix: "_apple_pay")
-  }
-
-  var rememberMeAcceptedCardTypesView: some View {
-    acceptedCardTypesPicker(title: "RememberMe accepted card types:",
-                            selectedTypes: $viewModel.rememberMeAcceptedCardTypes,
-                            cardTypes: allCardTypes,
-                            accessibilityIdentifierSuffix: "_remember_me")
-  }
-
   var updateAmountSettingView: some View {
     Toggle("Show update amount view", isOn: $viewModel.isShowUpdateView)
   }
@@ -804,6 +927,17 @@ extension CheckoutComponents.ApplePayButtonType {
     case .support: return "Support"
     case .contribute: return "Contribute"
     case .tip: return "Tip"
+    }
+  }
+}
+
+// MARK: - Stored Card display helpers
+
+extension CheckoutComponents.StoredCardDisplayMode {
+  var displayName: String {
+    switch self {
+    case .defaultCard: return "Default card"
+    case .all: return "All"
     }
   }
 }

--- a/SampleApplication/SampleApplication/Main/View/MainView.swift
+++ b/SampleApplication/SampleApplication/Main/View/MainView.swift
@@ -48,6 +48,11 @@ struct MainView: View {
       }
     }
     .padding()
+    .onChange(of: viewState) { newState in
+      if newState != .component {
+        viewModel.cvvTokenizationResult = nil
+      }
+    }
     .sheet(isPresented: $viewModel.showPaymentResult) {
       PaymentResultView(
         isSuccess: viewModel.paymentSucceeded,
@@ -99,31 +104,72 @@ extension MainView {
     ScrollView {
       if let componentsView = viewModel.checkoutComponentsView {
         componentsView
-        
-        switch viewModel.customButtonOperation {
-          
-        case .tokenization:
-          Button("Merchant Tokenization") {
-            viewModel.merchantTokenizationTapped()
+
+        if viewModel.selectedComponentType == .cvv {
+          // The CVV component tokenizes through the async `tokenize()` that returns the
+          // CVV token result, so it gets its own button instead of the generic ones below.
+          Button("CVV Tokenization") {
+            viewModel.cvvTokenizationTapped()
           }
           .padding()
-          
-        case .submitPayment:
-          switch (viewModel.showCardPayButton, viewModel.showApplePayButton, viewModel.showAPMPayButton) {
-          case (true, true, true):
-            EmptyView()
 
-          default:
-            // Staged methods (e.g. STC Pay) report `isPayButtonRequired == false`
-            // on their first stage, so keep the custom pay button hidden until
-            // the SDK signals it is required.
-            if viewModel.isPayButtonRequired {
-              Button("Submit") {
-                viewModel.submit()
-              }
-              .padding()
-            }
+          cvvTokenizationResultView()
+        } else {
+          customButtonView()
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  func cvvTokenizationResultView() -> some View {
+    switch viewModel.cvvTokenizationResult {
+    case .token(let token):
+      Text("CVV token: \(token)")
+        .accessibilityIdentifier(AccessibilityIdentifier.MainView.cvvTokenLabel.rawValue)
+        .font(.subheadline)
+        .foregroundColor(.green)
+        .multilineTextAlignment(.center)
+        .textSelection(.enabled)
+
+    case .failure(let message):
+      Text("CVV tokenization failed: \(message)")
+        .accessibilityIdentifier(AccessibilityIdentifier.MainView.cvvTokenizationErrorLabel.rawValue)
+        .font(.subheadline)
+        .foregroundColor(.red)
+        .multilineTextAlignment(.center)
+
+    case .none:
+      EmptyView()
+    }
+  }
+
+  @ViewBuilder
+  func customButtonView() -> some View {
+    switch viewModel.customButtonOperation {
+
+    case .tokenization:
+      Button("Merchant Tokenization") {
+        viewModel.merchantTokenizationTapped()
+      }
+      .padding()
+
+    case .submitPayment:
+      switch (viewModel.showCardPayButton, viewModel.showApplePayButton,
+              viewModel.showAPMPayButton, viewModel.showStoredCardPayButton) {
+      case (true, true, true, true):
+        EmptyView()
+
+      default:
+        // Staged methods (e.g. STC Pay) report `isPayButtonRequired == false`
+        // on their first stage, so keep the custom pay button hidden until
+        // the SDK signals it is required.
+        if viewModel.isPayButtonRequired {
+          Button("Submit") {
+            viewModel.submit()
           }
+          .accessibilityIdentifier(AccessibilityIdentifier.MainView.merchantSubmitButton.rawValue)
+          .padding()
         }
       }
     }
@@ -175,6 +221,19 @@ extension MainView {
           .accessibilityIdentifier(AccessibilityIdentifier.MainView.settingsButton.rawValue)
           .font(.system(size: 24))
           .foregroundStyle(.black)
+      }
+
+      Button {
+        viewModel.showCallbackLog = true
+      } label: {
+        Image(systemName: "info.circle")
+          .font(.system(size: 24))
+          .foregroundStyle(.black)
+      }
+      .accessibilityIdentifier(AccessibilityIdentifier.MainView.callbackLogButton.rawValue)
+      .accessibilityLabel("Callback Info")
+      .sheet(isPresented: $viewModel.showCallbackLog) {
+        CallbackLogView(store: viewModel.callbackInfoStore)
       }
     }
   }

--- a/SampleApplication/SampleApplication/Main/View/PaymentResultView.swift
+++ b/SampleApplication/SampleApplication/Main/View/PaymentResultView.swift
@@ -63,12 +63,14 @@ struct PaymentResultView: View {
         .opacity(animateMessage ? 1 : 0)
         .animation(.easeIn(duration: 0.5).delay(1.0), value: animateMessage)
       
-      Text("Generated token: \(token)")
-        .accessibilityIdentifier(AccessibilityIdentifier.PaymentResultView.generatedTokenLabel.rawValue)
-        .font(.subheadline)
-        .foregroundColor(.gray)
-        .opacity(animateMessage ? 1 : 0)
-        .animation(.easeIn(duration: 0.5).delay(1.0), value: animateMessage)
+      if !token.isEmpty {
+        Text("Generated token: \(token)")
+          .accessibilityIdentifier(AccessibilityIdentifier.PaymentResultView.generatedTokenLabel.rawValue)
+          .font(.subheadline)
+          .foregroundColor(.gray)
+          .opacity(animateMessage ? 1 : 0)
+          .animation(.easeIn(duration: 0.5).delay(1.0), value: animateMessage)
+      }
     }
   }
 

--- a/SampleApplication/SampleApplication/Main/ViewModel/MainViewModel+CallbacksProvider.swift
+++ b/SampleApplication/SampleApplication/Main/ViewModel/MainViewModel+CallbacksProvider.swift
@@ -9,29 +9,43 @@ import CheckoutComponentsSDK
 // MARK: - Callback Handlers
 
 extension MainViewModel {
+  nonisolated func logCallback(_ info: String) {
+    Task { @MainActor in
+      self.callbackInfoStore.add(info)
+    }
+  }
+
   func initialiseCallbacks() -> CheckoutComponents.Callbacks {
     .init(
-      onReady: { paymentMethod in
+      onReady: { [weak self] paymentMethod in
         debugPrint("onReady: Payment method: \(paymentMethod.name)")
+        self?.logCallback("[CONFIG] onReady: \(paymentMethod.name)")
       },
 
-      handleTap: { paymentMethod async -> Bool in
+      handleTap: { [weak self] paymentMethod async -> Bool in
         debugPrint("handleTap: Payment method: \(paymentMethod.name)")
+        self?.logCallback("[CONFIG] handleTap: \(paymentMethod.name)")
         return true
       },
 
       onChange: { [weak self] paymentMethod in
         debugPrint("onChange: Payment method: \(paymentMethod.name), isValid: \(paymentMethod.isValid), isPayButtonRequired: \(paymentMethod.isPayButtonRequired)")
+        self?.logCallback("[CONFIG] onChange: \(paymentMethod.name)")
         let isPayButtonRequired = paymentMethod.isPayButtonRequired
         Task { @MainActor in
           self?.isPayButtonRequired = isPayButtonRequired
         }
       },
-      
+
       onCardBinChanged: onCardBinChanged(),
 
-      onSubmit: { paymentMethod in
+      onSubmit: { [weak self] paymentMethod in
         debugPrint("onSubmit: Payment method: \(paymentMethod.name)")
+        self?.logCallback("[CONFIG] onSubmit: \(paymentMethod.name)")
+
+        Task { @MainActor in
+          self?.generatedToken = ""
+        }
       },
 
       onTokenized: onTokenized(),
@@ -45,7 +59,9 @@ extension MainViewModel {
   }
   
   func onCardBinChanged() -> (@Sendable (CardMetadata?) -> CheckoutComponents.CallbackResult)? {
-    { cardMetadata -> CheckoutComponents.CallbackResult in
+    { [weak self] cardMetadata -> CheckoutComponents.CallbackResult in
+      self?.logCallback("[CONFIG] onCardBinChanged: \(cardMetadata.map { "bin: \($0.bin), scheme: \($0.scheme)" } ?? "null")")
+
       guard let cardMetadata else {
         return .accepted
       }
@@ -63,8 +79,8 @@ extension MainViewModel {
       }
 
       // Reject credit cards
-      if cardMetadata.cardType == "credit" {
-        // return .rejected(message: "Credit cards are not accepted.")
+      if cardMetadata.cardType == "CREDIT" {
+//        return .rejected(message: "Credit cards are not accepted.")
       }
 
       // Otherwise, allow the payment to proceed
@@ -76,11 +92,12 @@ extension MainViewModel {
     { [weak self] tokenizationResult in
       guard let self else { return .rejected(message: nil) }
       
-      debugPrint("onTokenized: Token: \(tokenizationResult.data)")
+      debugPrint("onTokenized: Token: \(tokenizationResult)")
+      
       Task { @MainActor in
         self.generatedToken = tokenizationResult.data.token
       }
-      
+
       return .accepted
     }
   }
@@ -92,7 +109,8 @@ extension MainViewModel {
       guard let self else { return .failure }
       
       debugPrint("handleSubmit: Submit data: \(submitData)")
-      
+      self.logCallback("[CONFIG] handleSubmit")
+
       do {
         let paymentSessionSubmissionResult = try await self.submitPaymentSession(with: submitData)
         return .success(paymentSessionSubmissionResult)
@@ -106,6 +124,7 @@ extension MainViewModel {
     { [weak self] paymentMethod, paymentID in
       guard let self else { return }
       
+      self.logCallback("[CONFIG] onSuccess \(paymentMethod.name): \(paymentID)")
       Task { @MainActor in
         debugPrint("onSuccess: Payment method: \(paymentMethod.name) ....> Payment Id: \(paymentID)")
         self.paymentSucceeded = true
@@ -119,6 +138,7 @@ extension MainViewModel {
     { [weak self] error in
       guard let self else { return }
       
+      self.logCallback("[CONFIG] onError: \(error.errorCode)")
       Task { @MainActor in
         debugPrint("onError:  \(error)")
         self.paymentSucceeded = false

--- a/SampleApplication/SampleApplication/Main/ViewModel/MainViewModel.swift
+++ b/SampleApplication/SampleApplication/Main/ViewModel/MainViewModel.swift
@@ -30,12 +30,19 @@ enum CustomButtonOperation: String, CaseIterable {
   case submitPayment = "Submit Payment"
 }
 
+enum CVVTokenizationResult {
+  case token(String)
+  case failure(String)
+}
+
 @MainActor
 final class MainViewModel: ObservableObject {
   @Published var checkoutComponentsView: AnyView?
 
   @Published var showPaymentResult: Bool = false
   @Published var paymentSucceeded: Bool = true
+  let callbackInfoStore = CallbackInfoStore()
+  @Published var showCallbackLog: Bool = false
   @Published var paymentResultText: String = ""
   @Published var generatedToken: String = ""
   @Published var errorMessage: String = ""
@@ -78,6 +85,29 @@ final class MainViewModel: ObservableObject {
   @Published var isPaymentSessionConfigurationExpanded: Bool = false
   @Published var paymentSessionUsername: String = "Test"
   @Published var paymentSessionUserEmail: String = "customer+test@checkout.com"
+  
+  // CVV
+  @Published var isCVVExpanded: Bool = false
+  @Published var selectedCVVLengths: Set<CVVLength> = [.three, .four]
+  @Published var cvvTokenizationResult: CVVTokenizationResult?
+
+  var cvvLength: [UInt] {
+    selectedCVVLengths.map(\.rawValue).sorted()
+  }
+
+  //Saved Card
+  @Published var isStoredCardExpanded: Bool = false
+  @Published var storedCardDisplayMode: CheckoutComponents.StoredCardDisplayMode = .defaultCard
+  @Published var showStoredCardPayButton: Bool = true
+  @Published var storedCardPaymentButtonAction: CheckoutComponents.PaymentButtonAction = .payment
+  @Published var storedCardCaptureCVV: Bool = false
+  @Published var storedCardAcceptedCardSchemes: Set<CardScheme> = []
+  @Published var storedCardAcceptedCardTypes: Set<CheckoutComponents.CardType> = []
+  @Published var storePaymentDetails: StorePaymentDetailsOption = .collectConsent
+  @Published var storedCardSource: StoredCardSource = .customerId
+  @Published var customerId: String = ""
+  @Published var instrumentIds: String = ""
+  @Published var defaultInstrumentId: String = ""
 
   // RememberMe
   @Published var isRememberMeExpanded: Bool = false
@@ -207,9 +237,15 @@ final class MainViewModel: ObservableObject {
 
 extension MainViewModel {
   func makeComponent() async throws {
+    cvvTokenizationResult = nil
+    generatedToken = ""
+
     do {
-      let paymentSession = try await createPaymentSession()
-      paymentSessionId = paymentSession.id
+      var paymentSession: PaymentSession?
+      if !selectedComponentType.isSessionless {
+        paymentSession = try await createPaymentSession()
+      }
+      paymentSessionId = paymentSession?.id ?? ""
       let checkoutComponentsSDK = try await initialiseCheckoutComponentsSDK(with: paymentSession)
       createdCheckoutComponentsSDK = checkoutComponentsSDK
       let component = try createComponent(with: checkoutComponentsSDK)
@@ -232,6 +268,30 @@ extension MainViewModel {
 }
 
 extension MainViewModel {
+  var storedCardConfiguration: StoredCardConfiguration? {
+    switch storedCardSource {
+    case .none:
+      return nil
+
+    case .instrumentIds:
+      let ids = instrumentIds
+        .split(separator: ",")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+      guard !ids.isEmpty else {
+        return nil
+      }
+
+      let defaultId = defaultInstrumentId.trimmingCharacters(in: .whitespaces)
+      return StoredCardConfiguration(instrumentIds: ids,
+                                     defaultInstrumentId: defaultId.isEmpty ? nil : defaultId)
+
+    case .customerId:
+      let id = customerId.trimmingCharacters(in: .whitespaces)
+      return id.isEmpty ? nil : StoredCardConfiguration(customerId: id)
+    }
+  }
+
   // Step 1: Create Payment Session
   func createPaymentSession() async throws -> PaymentSession {
     let address = Address(
@@ -252,7 +312,7 @@ extension MainViewModel {
       name: !paymentSessionUsername.isEmpty ? paymentSessionUsername : "",
       phone: paymentSessionPhoneModel
     )
-
+    
     let paymentSessionRequest = PaymentSessionRequest(
       amount: amount,
       currency: selectedCurrency.rawValue,
@@ -269,7 +329,9 @@ extension MainViewModel {
       failureURL: Constants.failureURL,
       threeDS: .init(enabled: true, attemptN3D: true),
       processingChannelID: resolvedProcessingChannelID,
-      paymentMethodConfiguration: PaymentMethodConfiguration(applepay: ApplePayConfiguration(totalType: selectedApplePayType.rawValue)),
+      paymentMethodConfiguration: PaymentMethodConfiguration(card: CardConfiguration(storePaymentDetails: storePaymentDetails.requestValue),
+                                                             storedCard: storedCardConfiguration,
+                                                             applepay: ApplePayConfiguration(totalType: selectedApplePayType.rawValue)),
       locale: paymentSessionSelectedLocale.localeString,
       items: [
         Item(name: "Guitar",
@@ -290,7 +352,8 @@ extension MainViewModel {
   }
 
   // Step 2: Initialise an instance of Checkout Components SDK
-  func initialiseCheckoutComponentsSDK(with paymentSession: PaymentSession) async throws (CheckoutComponents.Error) -> CheckoutComponents {
+  // Pass `nil` to configure the SDK for sessionless components.
+  func initialiseCheckoutComponentsSDK(with paymentSession: PaymentSession?) async throws (CheckoutComponents.Error) -> CheckoutComponents {
     let configuration = try await CheckoutComponents.Configuration(
       paymentSession: paymentSession,
       publicKey: resolvedPublicKey,
@@ -308,9 +371,17 @@ extension MainViewModel {
   func createComponent(with checkoutComponentsSDK: CheckoutComponents) throws (CheckoutComponents.Error) -> Any {
     switch selectedComponentType {
     case .flow:
-      return try checkoutComponentsSDK.create(.flow(options: selectedPaymentMethods, providers: .init(providers: apmProviders, showPayButton: showAPMPayButton)))
+      return try checkoutComponentsSDK.create(.flow(options: selectedPaymentMethods,
+                                                    providers: .init(providers: apmProviders,
+                                                                     showPayButton: showAPMPayButton)))
+    case .address:
+      return try checkoutComponentsSDK.create(.address(configuration: selectedAddressConfiguration.addressConfiguration!))
+    case .cvv:
+      return try checkoutComponentsSDK.create(.cvv(configuration: CardCVVConfiguration(cvvLength: cvvLength)))
     case .card:
       return try checkoutComponentsSDK.create(getCardPaymentMethod())
+    case .storedCard:
+      return try checkoutComponentsSDK.create(getStoredCardPaymentMethod())
     case .applePay:
       return try checkoutComponentsSDK.create(getApplePayPaymentMethod())
     #if canImport(CheckoutPaymentMethods)
@@ -462,6 +533,8 @@ extension MainViewModel {
       methods.insert(getApplePayPaymentMethod())
     }
 
+    methods.insert(getStoredCardPaymentMethod())
+
     return methods
   }
   
@@ -494,6 +567,22 @@ extension MainViewModel {
                  rememberMeConfiguration: rememberMeConfig)
   }
   
+  func getStoredCardPaymentMethod() -> CheckoutComponents.PaymentMethod {
+    let storedCardConfiguration = CheckoutComponents.StoredCardConfiguration(showPayButton: showStoredCardPayButton,
+                                                                              paymentButtonAction: storedCardPaymentButtonAction,
+                                                                              captureCVV: storedCardCaptureCVV,
+                                                                              displayMode: storedCardDisplayMode,
+                                                                              acceptedCardSchemes: storedCardAcceptedCardSchemes,
+                                                                              acceptedCardTypes: storedCardAcceptedCardTypes)
+    
+    return .storedCard(storedCardConfiguration: storedCardConfiguration,
+                       cardConfiguration: .init(displayCardHolderName: displayCardHolderName,
+                                                acceptedCardSchemes: cardAcceptedCardSchemes,
+                                                acceptedCardTypes: cardAcceptedCardTypes,
+                                                hideSecurityCode: hideSecurityCode,
+                                                cardholderNameMaxLength: cardHolderNameMaxLength))
+  }
+  
   func getApplePayPaymentMethod() -> CheckoutComponents.PaymentMethod {
     .applePay(merchantIdentifier: "merchant.com.ios.mobile.flow.sandbox",
               showPayButton: showApplePayButton,
@@ -505,6 +594,7 @@ extension MainViewModel {
   
   func resetToDefaultConfiguration() {
     checkoutComponentsView = nil
+    cvvTokenizationResult = nil
     selectedComponentType = .flow
     selectedPaymentMethodTypes = [.card, .applePay, .tabby, .tamara, .stcPay, .klarna]
     showCardPayButton = true
@@ -543,6 +633,32 @@ extension MainViewModel {
       return
     }
     component.tokenize()
+  }
+  
+  func cvvTokenizationTapped() {
+    guard let component = component as? CheckoutComponents.ActionableComponent else {
+      print("Component does not conform to Tokenizable. e.g. It might be an Address Component or alike")
+      return
+    }
+
+    cvvTokenizationResult = nil
+
+    Task {
+      let cvvTokenResult = await component.tokenize()
+
+      switch cvvTokenResult {
+      case .success(let cvvToken):
+        print(cvvToken.token)
+        cvvTokenizationResult = .token(cvvToken.token)
+      case .failure(let failure):
+        print(failure)
+        
+        if case .componentInvalid = failure.errorCode { return }
+        cvvTokenizationResult = .failure(failure.errorCode.description)
+      case .none:
+        break
+      }
+    }
   }
 }
 

--- a/SampleApplication/SampleApplication/NetworkLayer/PaymentSessionRequest.swift
+++ b/SampleApplication/SampleApplication/NetworkLayer/PaymentSessionRequest.swift
@@ -52,7 +52,13 @@ struct ThreeDS: Encodable {
 }
 
 struct PaymentMethodConfiguration: Encodable {
+  let card: CardConfiguration
+  let storedCard: StoredCardConfiguration?
   let applepay: ApplePayConfiguration
+}
+
+struct CardConfiguration: Encodable {
+  let storePaymentDetails: String?
 }
 
 struct ApplePayConfiguration: Encodable {
@@ -60,6 +66,26 @@ struct ApplePayConfiguration: Encodable {
   
   enum CodingKeys: String, CodingKey {
     case totalType = "total_type"
+  }
+}
+
+struct StoredCardConfiguration: Encodable {
+  let customerId: String?
+  let instrumentIds: [String]?
+  let defaultInstrumentId: String?
+
+  init(customerId: String? = nil,
+       instrumentIds: [String]? = nil,
+       defaultInstrumentId: String? = nil) {
+    self.customerId = customerId
+    self.instrumentIds = instrumentIds
+    self.defaultInstrumentId = defaultInstrumentId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case customerId = "customer_id"
+    case instrumentIds = "instrument_ids"
+    case defaultInstrumentId = "default_instrument_id"
   }
 }
 

--- a/SampleApplication/SampleApplicationTests/StoredCardConfigurationTests.swift
+++ b/SampleApplication/SampleApplicationTests/StoredCardConfigurationTests.swift
@@ -1,0 +1,82 @@
+//  Copyright © 2026 Checkout.com. All rights reserved.
+
+import XCTest
+@testable import SampleApplication
+
+@MainActor
+final class StoredCardConfigurationTests: XCTestCase {
+
+  // MARK: - MainViewModel.storedCardConfiguration
+
+  func test_noneSource_omitsStoredCard() {
+    let viewModel = MainViewModel()
+    viewModel.storedCardSource = .none
+
+    XCTAssertNil(viewModel.storedCardConfiguration)
+  }
+
+  func test_instrumentIdsSource_splitsAndTrimsTheList() {
+    let viewModel = MainViewModel()
+    viewModel.storedCardSource = .instrumentIds
+    viewModel.instrumentIds = " src_one , src_two ,, "
+
+    let configuration = viewModel.storedCardConfiguration
+
+    XCTAssertEqual(configuration?.instrumentIds, ["src_one", "src_two"])
+    XCTAssertNil(configuration?.customerId)
+    XCTAssertNil(configuration?.defaultInstrumentId)
+  }
+
+  func test_instrumentIdsSource_keepsDefaultInstrumentId() {
+    let viewModel = MainViewModel()
+    viewModel.storedCardSource = .instrumentIds
+    viewModel.instrumentIds = "src_one,src_two"
+    viewModel.defaultInstrumentId = " src_two "
+
+    XCTAssertEqual(viewModel.storedCardConfiguration?.defaultInstrumentId, "src_two")
+  }
+
+  func test_instrumentIdsSource_withoutAnyId_omitsStoredCard() {
+    let viewModel = MainViewModel()
+    viewModel.storedCardSource = .instrumentIds
+    viewModel.instrumentIds = " , "
+
+    XCTAssertNil(viewModel.storedCardConfiguration)
+  }
+
+  func test_customerIdSource_ignoresTheInstrumentFields() {
+    let viewModel = MainViewModel()
+    viewModel.storedCardSource = .customerId
+    viewModel.customerId = "cus_one"
+    viewModel.instrumentIds = "src_one"
+    viewModel.defaultInstrumentId = "src_one"
+
+    let configuration = viewModel.storedCardConfiguration
+
+    XCTAssertEqual(configuration?.customerId, "cus_one")
+    XCTAssertNil(configuration?.instrumentIds)
+    XCTAssertNil(configuration?.defaultInstrumentId)
+  }
+
+  func test_customerIdSource_withoutId_omitsStoredCard() {
+    let viewModel = MainViewModel()
+    viewModel.storedCardSource = .customerId
+    viewModel.customerId = "  "
+
+    XCTAssertNil(viewModel.storedCardConfiguration)
+  }
+
+  // MARK: - Encoding
+
+  func test_encoding_usesSnakeCaseKeysAndSkipsUnsetFields() throws {
+    let configuration = StoredCardConfiguration(instrumentIds: ["src_one", "src_two"],
+                                                defaultInstrumentId: "src_two")
+
+    let data = try JSONEncoder().encode(configuration)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    XCTAssertEqual(json["instrument_ids"] as? [String], ["src_one", "src_two"])
+    XCTAssertEqual(json["default_instrument_id"] as? String, "src_two")
+    XCTAssertNil(json["customer_id"])
+  }
+}


### PR DESCRIPTION
Automated release of CheckoutComponentsSDK 2.6.0

### Changelog
- [ADDED] Merchant Saved Card component
- [ADDED] CVV component
- [ADDED] Support for Remember Me countries: Jordan, Kuwait, Morocco, Palestine, and Tunisia
- [UPDATED] OnTokenised callback now includes consent checkbox value
- [UPDATED] Remember Me wallet now displays a Pay button for each row